### PR TITLE
Accessibility Suggestion

### DIFF
--- a/projeto/frontend/src/styles/form.css
+++ b/projeto/frontend/src/styles/form.css
@@ -35,7 +35,7 @@
   padding: 15px;
   margin-right: 10px;
   border-radius: 12px;
-  outline: none;
+  outline-color: transparent;
   border: none;
   box-sizing: border-box;
   color: var(--text);


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8